### PR TITLE
Updated package.json for new Aurelia packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
       "lib": "dist/amd"
     },
     "dependencies": {
-      "aurelia-binding": "github:aurelia/binding@^0.10.2",
-      "aurelia-bootstrapper": "github:aurelia/bootstrapper@^0.18.0",
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.11.2",
-      "aurelia-framework": "github:aurelia/framework@^0.17.0",
-      "aurelia-loader": "github:aurelia/loader@^0.10.0",
-      "aurelia-logging": "github:aurelia/logging@^0.8.0",
-      "aurelia-metadata": "github:aurelia/metadata@^0.9.0",
-      "aurelia-router": "github:aurelia/router@^0.13.0",
-      "aurelia-templating": "github:aurelia/templating@^0.16.0",
-      "aurelia-templating-resources": "github:aurelia/templating-resources@^0.16.1"
+      "aurelia-binding": "github:aurelia/binding@^0.11.0",
+      "aurelia-bootstrapper": "github:aurelia/bootstrapper@^0.19.0",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.12.1",
+      "aurelia-framework": "github:aurelia/framework@^0.18.0",
+      "aurelia-loader": "github:aurelia/loader@^0.11.0",
+      "aurelia-logging": "github:aurelia/logging@^0.9.0",
+      "aurelia-metadata": "github:aurelia/metadata@^0.10.1",
+      "aurelia-router": "github:aurelia/router@^0.14.0",
+      "aurelia-templating": "github:aurelia/templating@^0.17.2",
+      "aurelia-templating-resources": "github:aurelia/templating-resources@^0.17.0"
     },
     "devDependencies": {
       "babel": "npm:babel-core@^5.8.22",


### PR DESCRIPTION
Aurelia has updated their packages. One of the big updates is the updated dependency of core-js. Have two versions of core-js in a project slows down page load _significantly_. Because this package depended on old versions of Aurelia, it was pulling old versions of core-js, causing two versions of core-js to be loaded.
